### PR TITLE
Added support for files with the ID 'terraform'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,5 +77,6 @@ const linkProvider: vscode.DocumentLinkProvider = {
 
 export function activate(context: vscode.ExtensionContext) {
   const disposeLinkProvider = vscode.languages.registerDocumentLinkProvider('terraform', linkProvider);
-  context.subscriptions.push(disposeLinkProvider);
+  const tfDisposeLinkProvider = vscode.languages.registerDocumentLinkProvider('tf', linkProvider);
+  context.subscriptions.push(disposeLinkProvider, tfDisposeLinkProvider);
 }


### PR DESCRIPTION


The official Hashicorp Terraform plugin is a bit pants, and rather difficult to configure in certain circumstances.

This PR adds support for the `terraform` file ID (used by Anton's Kulikov's Terraform plugin) while keeping support for `tf` (the official file ID used by the official plugin).