### PR TITLE
Feature/databricks provider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,10 @@ const getLineMatchResultUri: (lmr: LineMatchResult) => vscode.Uri | undefined =
   ({ dataOrResource, resourceType }) => {
     const { provider, name } = resourceTypeToProviderAndName(resourceType) || {};
     if (!provider || !name) { return; }
-    return vscode.Uri.parse(`https://www.terraform.io/docs/providers/${provider}/${dataOrResource.charAt(0)}/${name}.html`);
+    if (provider == 'databricks') {
+      return vscode.Uri.parse(`https://registry.terraform.io/providers/databrickslabs/${provider}/latest/docs/${dataOrResource.charAt(0)}/${name}`);
+    }
+    return vscode.Uri.parse(`https://registry.terraform.io/providers/hashicorp/${provider}latest/docs/${dataOrResource.charAt(0)}/${name}`);
   };
 
 function isNotUndefined<T>(v: T | undefined): v is T {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,14 +38,23 @@ const resourceTypeToProviderAndName: (resourceType: string) => { provider: strin
     return { provider, name };
   };
 
+const providersNamespace: (provider: string) => string =
+  (provider) => {
+    if (provider === "databricks") { return `databrickslabs/${provider}`; }
+    return `hashicorp/${provider}`
+  };
+
+const dataOrResourceURI: (dataOrResource: TerraformDataOrResource) => string =
+  (dataOrResource) => {
+    if (dataOrResource === "data") { return `${dataOrResource}-sources`; }
+    return `${dataOrResource}s`
+  };
+
 const getLineMatchResultUri: (lmr: LineMatchResult) => vscode.Uri | undefined =
   ({ dataOrResource, resourceType }) => {
     const { provider, name } = resourceTypeToProviderAndName(resourceType) || {};
     if (!provider || !name) { return; }
-    if (provider == 'databricks') {
-      return vscode.Uri.parse(`https://registry.terraform.io/providers/databrickslabs/${provider}/latest/docs/${dataOrResource.charAt(0)}/${name}`);
-    }
-    return vscode.Uri.parse(`https://registry.terraform.io/providers/hashicorp/${provider}latest/docs/${dataOrResource.charAt(0)}/${name}`);
+    return vscode.Uri.parse(`https://registry.terraform.io/providers/${providersNamespace(provider)}/latest/docs/${dataOrResourceURI(dataOrResource)}/${name}`);
   };
 
 function isNotUndefined<T>(v: T | undefined): v is T {

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,9 +116,9 @@ acorn-jsx@^5.1.0:
   integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
 acorn@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,9 +1009,9 @@ locate-path@^3.0.0:
     path-exists "^3.0.0"
 
 lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,9 +1732,9 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 yargs-parser@13.1.1, yargs-parser@^13.1.1:
   version "13.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,9 +740,9 @@ get-caller-file@^2.0.1:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 glob-parent@^5.0.0, glob-parent@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 


### PR DESCRIPTION
Terraform registry has updated the way their URIs are generated to include a namespace, e.g. `aws` is now `hashicorp/aws`. There are a couple of other changes to the standard URI structure for the docs. 

This issue is mostly not noticed because hashicorp have auto-forwarding on all their old links to the new links, but it doesn't work for providers other than hashicorp. I noticed this when trying to link to the docs for the `databrickslabs/databricks` provider.

This PR adds a new function that could be extended to other providers fairly easily.

I have also merged a bunch of the dependabot PRs to bump some node package versions. 

I tested this using `npm run test`, and also ran debugging with F5 and tested links from a terraform repo project I am working on so it should be stable.